### PR TITLE
Make analyzer a constructor, fix name and Doc

### DIFF
--- a/cmd/responsewriter-lint/main.go
+++ b/cmd/responsewriter-lint/main.go
@@ -7,5 +7,5 @@ import (
 )
 
 func main() {
-	singlechecker.Main(analyzer.Analyzer)
+	singlechecker.Main(analyzer.New())
 }

--- a/pkg/analyzer/analyzer.go
+++ b/pkg/analyzer/analyzer.go
@@ -8,11 +8,13 @@ import (
 	"golang.org/x/tools/go/ast/inspector"
 )
 
-var Analyzer = &analysis.Analyzer{
-	Name:     "responsewriterorder",
-	Doc:      "Checks that printf-like functions are named with `f` at the end.",
-	Run:      run,
-	Requires: []*analysis.Analyzer{inspect.Analyzer},
+func New() *analysis.Analyzer {
+	return &analysis.Analyzer{
+		Name:     "responsewriterlint",
+		Doc:      "Checks the order of method calls on http.ResponseWriter to flag potential bugs from out of order calls",
+		Run:      run,
+		Requires: []*analysis.Analyzer{inspect.Analyzer},
+	}
 }
 
 func run(pass *analysis.Pass) (interface{}, error) {

--- a/pkg/analyzer/analyzer_test.go
+++ b/pkg/analyzer/analyzer_test.go
@@ -17,5 +17,5 @@ func TestAll(t *testing.T) {
 	}
 
 	testdata := filepath.Join(filepath.Dir(filepath.Dir(wd)), "testdata")
-	analysistest.Run(t, testdata, analyzer.Analyzer, "p")
+	analysistest.Run(t, testdata, analyzer.New(), "p")
 }


### PR DESCRIPTION
Small change, fixed the name and doc, and instead of the analyzer being a global, it is now returned from a constructor.